### PR TITLE
Create master dataset with short code exclusion

### DIFF
--- a/django_project/dashboard/tests/test_api_views.py
+++ b/django_project/dashboard/tests/test_api_views.py
@@ -104,6 +104,7 @@ from georepo.utils.dataset_view import (
 from georepo.utils.dataset_view import (
     init_view_privacy_level
 )
+from core.models.preferences import SitePreferences
 
 
 def mocked_cache_get(self, *args, **kwargs):
@@ -2179,6 +2180,18 @@ class TestApiViews(TestCase):
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.data['is_available'])
+        # Check OAB for master dataset
+        post_data = {
+            'short_code': SitePreferences.preferences().short_code_exclusion
+        }
+        request = self.factory.post(
+            reverse('check-dataset-short-code'), post_data, format='json'
+        )
+        request.user = user
+        view = CheckDatasetShortCode.as_view()
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data['is_available'])
 
     @mock.patch(
         'modules.admin_boundaries.config.'


### PR DESCRIPTION
We can now create master dataset:
![2023-08-07_02-21](https://github.com/unicef-drp/GeoRepo-OS/assets/5819076/f9fbb46f-fb94-43d5-a314-1289f5a07e42)
