### PR TITLE
Fix missing azure storage variables

### DIFF
--- a/django_project/georepo/api_views/tile.py
+++ b/django_project/georepo/api_views/tile.py
@@ -28,7 +28,7 @@ class TileAPIView(APIView):
         z = kwargs.get('z')
         x = kwargs.get('x')
         y = kwargs.get('y')
-        if settings.USE_AZURE:
+        if settings.USE_AZURE and StorageContainerClient:
             source = f'layer_tiles/{resource_uuid}/{z}/{x}/{y}'
             try:
                 bc = StorageContainerClient.get_blob_client(blob=source)

--- a/django_project/georepo/utils/azure_blob_storage.py
+++ b/django_project/georepo/utils/azure_blob_storage.py
@@ -230,7 +230,10 @@ def get_tegola_cache_config(connection_string, container_name):
 
 StorageServiceClient = None
 StorageContainerClient = None
-if settings.USE_AZURE:
+if (
+    settings.USE_AZURE and settings.AZURE_STORAGE and
+    settings.AZURE_STORAGE_CONTAINER
+):
     StorageServiceClient = BlobServiceClient.from_connection_string(
         settings.AZURE_STORAGE
     )


### PR DESCRIPTION
Missing azure variable causing exception in container without the variable set.
Preview:
![Screenshot_4642](https://github.com/unicef-drp/GeoRepo-OS/assets/5819076/3c4d0a63-e202-42e3-9539-cd643991a971)

No exception when we run django initialize.py
![Screenshot_4643](https://github.com/unicef-drp/GeoRepo-OS/assets/5819076/278747dc-8bf7-4a53-a88a-98fcb36631a7)
