### PR TITLE
Open Swagger Docs link in new page

### DIFF
--- a/django_project/core/templates/drf-yasg/swagger-ui.html
+++ b/django_project/core/templates/drf-yasg/swagger-ui.html
@@ -116,6 +116,7 @@
                 let link = document.createElement("a");
                 link.className = "api-doc";
                 link.href = info.info;
+                link.target = '_blank';
                 link.innerText = "Read API Documentation";
                 link.style.cssText = 'font-size:medium;margin-top:20px;'
                 document.querySelector('hgroup.main').appendChild(link)


### PR DESCRIPTION
This PR for https://github.com/unicef-drp/GeoRepo/issues/946#issuecomment-1723079662
The documentation URL at the top of Swagger page is now opened in the new tab when clicked.