### PR TITLE
use find_entity_upload function to lock entity upload before processing

### DIFF
--- a/django_project/georepo/tests/test_validation.py
+++ b/django_project/georepo/tests/test_validation.py
@@ -6,6 +6,7 @@ from django.contrib.gis.geos import GEOSGeometry
 from django.test import TestCase, override_settings, TransactionTestCase
 from django.db import transaction, IntegrityError
 
+from django.utils import timezone
 from georepo.models import GeographicalEntity, IdType, EntityType
 from georepo.tests.model_factories import (
     DatasetF, LanguageF, GeographicalEntityF,
@@ -928,7 +929,7 @@ class FindEntityUploadTestCase(TransactionTestCase):
                 EntityUploadStatus.objects.filter(id=entity_upload.id),
                 STARTED,
                 PROCESSING,
-                '1'
+                timezone.now()
             )
             self.assertTrue(upload)
         # lock should be released, but upload has been updated to PROCESSING
@@ -937,7 +938,7 @@ class FindEntityUploadTestCase(TransactionTestCase):
                 EntityUploadStatus.objects.filter(id=entity_upload.id),
                 STARTED,
                 PROCESSING,
-                '1'
+                timezone.now()
             )
             self.assertFalse(upload)
 
@@ -958,7 +959,7 @@ class FindEntityUploadTestCase(TransactionTestCase):
                 EntityUploadStatus.objects.filter(id=entity_upload.id),
                 STARTED,
                 PROCESSING,
-                '1'
+                timezone.now()
             )
             self.assertTrue(upload)
 
@@ -970,6 +971,6 @@ class FindEntityUploadTestCase(TransactionTestCase):
                     ),
                     STARTED,
                     PROCESSING,
-                    '1'
+                    timezone.now()
                 )
                 self.assertFalse(upload)


### PR DESCRIPTION
This is for https://github.com/unicef-drp/GeoRepo/issues/928. The function to lock (using select for update) entity upload object before starting to process the validation was already implemented when the validation task type was periodic task. I reused the function so now before validation process begins, the task will try to check and update the object status to Processing.

Preview when the upload is rejected once it has been picked up by other job:
![2023-10-16_11-46](https://github.com/unicef-drp/GeoRepo-OS/assets/5819076/9c3bc083-76e6-4f48-a90e-d971a282017f)
