### PR TITLE
Fix test failed sync status

### DIFF
--- a/django_project/dashboard/src/views/SyncStatus/List.tsx
+++ b/django_project/dashboard/src/views/SyncStatus/List.tsx
@@ -30,6 +30,7 @@ import LinearProgress from '@mui/material/LinearProgress';
 import SyncIcon from '@mui/icons-material/Sync';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import SyncProblemIcon from '@mui/icons-material/SyncProblem';
 import { DatasetDetailItemInterface } from "../../models/dataset";
 
@@ -177,6 +178,14 @@ const VIEW_LIST_URL = '/api/view-sync-list/'
 const TRIGGER_SYNC_API_URL = '/api/sync-view/'
 const FilterIcon: any = FilterAlt
 
+const getQueued = () => {
+  return (
+    <span className='sync-status-desc-container'>
+      <HourglassEmptyIcon color='info' fontSize='small' />
+      <span className='sync-status-desc'>{'Queued but not running yet'}</span>
+    </span>
+  )
+}
 const getSyncing = (progress: number) => {
   return (
     <span className='running-status'>
@@ -471,6 +480,8 @@ export default function ViewSyncList(props: DatasetDetailItemInterface) {
                 return getSynced('Vector tiles are synced')
               } else if (_status === 'syncing') {
                 return getSyncing(_progress)
+              } else if (_status === 'Queued') {
+                return getQueued()
               } else if (_status === 'error') {
                 if (_simplificationStatus !== 'synced') {
                   return (
@@ -494,7 +505,7 @@ export default function ViewSyncList(props: DatasetDetailItemInterface) {
   
         _columns.push({
           name: 'product_sync_status',
-          label: 'Data Product',
+          label: 'Data Products',
           options: {
             customBodyRender: (value: any, tableMeta: any, updateValue: any) => {
               let rowData = tableMeta.rowData
@@ -511,6 +522,8 @@ export default function ViewSyncList(props: DatasetDetailItemInterface) {
                 return getSynced('Data products are synced')
               } else if (_status === 'syncing') {
                 return getSyncing(_progress)
+              } else if (_status === 'Queued') {
+                return getQueued()
               } else if (_status === 'error') {
                 return (
                   getError('Click to retrigger data products generation', !rowData[2].includes('Manage'), (e: any) => {
@@ -552,7 +565,7 @@ export default function ViewSyncList(props: DatasetDetailItemInterface) {
               let _syncButtonDisabled = (rowData[8] === 'synced' && rowData[9] === 'synced') || (rowData[8] === 'syncing' || rowData[9] === 'syncing')
               const getSyncText = () => {
                 if (_syncButtonDisabled) {
-                  return 'Vector Tile and Data Product are synchronized'
+                  return 'Vector Tile and Data Products are synchronized'
                 }
                 if (_simplificationStatus !== 'synced') return 'Please trigger simplification before regenerate vector tiles!'
                 return 'Synchronize'

--- a/django_project/dashboard/src/views/View/ViewSync.tsx
+++ b/django_project/dashboard/src/views/View/ViewSync.tsx
@@ -296,7 +296,7 @@ export default function ViewSync(props: ViewResourceInterface) {
                         <ThemeButton
                           variant={'secondary'}
                           onClick={regenerateProductData}
-                          title={'Regenerate Product Data'}
+                          title={'Regenerate Data Products'}
                           icon={null}
                         />
                       </Grid>

--- a/django_project/dashboard/tests/test_sync/test_view.py
+++ b/django_project/dashboard/tests/test_sync/test_view.py
@@ -4,20 +4,42 @@ __copyright__ = ('Copyright 2023, Unicef')
 
 import urllib.parse
 
+import json
+from django.contrib.gis.geos import GEOSGeometry
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework.test import APIRequestFactory
-
+from georepo.models.dataset_view import DatasetViewResource
 from dashboard.api_views.view_sync import ViewSyncList
 from georepo.tests.model_factories import (
-    UserF, DatasetF, DatasetViewF, ModuleF
+    UserF, DatasetF, DatasetViewF, ModuleF,
+    GeographicalEntityF,
+    EntityTypeF,
 )
 from georepo.utils.permission import (
     grant_dataset_manager
 )
+from core.settings.utils import absolute_path
+from georepo.utils.dataset_view import (
+    create_sql_view,
+    init_view_privacy_level,
+    calculate_entity_count_in_view
+)
 
 
 class TestViewSyncList(TestCase):
+
+    def set_view_as_synced(self, view):
+        create_sql_view(view)
+        init_view_privacy_level(view)
+        # init view entity count
+        calculate_entity_count_in_view(view)
+        resources = DatasetViewResource.objects.filter(
+            dataset_view=view,
+            entity_count__gt=0
+        )
+        for resource in resources:
+            resource.set_synced(vector_tiles=True, product=True)
 
     def setUp(self) -> None:
         self.factory = APIRequestFactory()
@@ -28,12 +50,35 @@ class TestViewSyncList(TestCase):
             module=self.module,
             generate_adm0_default_views=True
         )
+        self.entity_type = EntityTypeF.create(label='Country')
+        geojson_0_1_path = absolute_path(
+            'dashboard', 'tests',
+            'geojson_dataset', 'level_0_1.geojson')
+        with open(geojson_0_1_path) as geojson:
+            data = json.load(geojson)
+        geom_str = json.dumps(data['features'][0]['geometry'])
+        self.geographical_entity = GeographicalEntityF.create(
+            dataset=self.dataset,
+            type=self.entity_type,
+            is_validated=True,
+            is_approved=True,
+            is_latest=True,
+            geometry=GEOSGeometry(geom_str),
+            internal_code='PAK',
+            revision_number=1
+        )
         self.superuser = UserF.create(is_superuser=True)
         self.creator = UserF.create()
         self.dataset_view_1 = DatasetViewF.create(
             dataset=self.dataset,
-            created_by=self.creator
+            created_by=self.creator,
+            query_string=(
+                f'select * from georepo_geographicalentity where '
+                f'dataset_id={self.dataset.id}'
+            )
         )
+        self.set_view_as_synced(self.dataset_view_1)
+        self.dataset_view_1.refresh_from_db()
         grant_dataset_manager(self.dataset_view_1.dataset, self.creator)
 
     def test_list_views(self):
@@ -73,7 +118,7 @@ class TestViewSyncList(TestCase):
             'simplification_status': 'out_of_sync',
             'simplification_progress': 0.0,
             'vector_tiles_progress': 0.0,
-            'product_progress': 0.0,
+            'product_progress': 100.0,
             'permissions': ['Manage', 'Read']
         }
         self.assertEqual(

--- a/django_project/georepo/tests/test_check_affected_dataset_views.py
+++ b/django_project/georepo/tests/test_check_affected_dataset_views.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
 from georepo.models import (
-    DatasetView
+    DatasetView, DatasetViewResource
 )
 from georepo.tasks.dataset_view import check_affected_dataset_views
 from georepo.tests.model_factories import (
@@ -21,7 +21,8 @@ from georepo.tests.model_factories import (
 from georepo.utils import absolute_path
 from georepo.utils.dataset_view import (
     create_sql_view,
-    init_view_privacy_level
+    init_view_privacy_level,
+    calculate_entity_count_in_view
 )
 from georepo.utils.permission import (
     grant_dataset_manager
@@ -71,15 +72,22 @@ class TestCheckAffectedViews(TestCase):
                 f'dataset_id={self.dataset_1.id}'
             )
         )
-        create_sql_view(self.dataset_view_1)
-        init_view_privacy_level(self.dataset_view_1)
-        DatasetView.objects.filter(
+        views = DatasetView.objects.filter(
             dataset=self.dataset_1
-        ).update(
-            product_sync_status=DatasetView.SyncStatus.SYNCED,
-            vector_tile_sync_status=DatasetView.SyncStatus.SYNCED
         )
+        for view in views:
+            create_sql_view(view)
+            init_view_privacy_level(view)
+            # init view entity count
+            calculate_entity_count_in_view(view)
+            resources = DatasetViewResource.objects.filter(
+                dataset_view=view,
+                entity_count__gt=0
+            )
+            for resource in resources:
+                resource.set_synced(vector_tiles=True, product=True)
         grant_dataset_manager(self.dataset_view_1.dataset, self.creator)
+        self.dataset_view_1.refresh_from_db()
 
     def test_affect_all_view_1_entity(self):
         """
@@ -165,20 +173,23 @@ class TestCheckAffectedViews(TestCase):
         self.dataset_view_1.save()
         create_sql_view(self.dataset_view_1)
         init_view_privacy_level(self.dataset_view_1)
+        # init view entity count
+        calculate_entity_count_in_view(self.dataset_view_1)
         check_affected_dataset_views(
             dataset_id=self.dataset_1.id,
             entity_id=self.geographical_entity.id
         )
 
         # Dataset View 1 is not affected, since it does not contain the entity.
+        # default status if no entity is out of synced
         self.dataset_view_1.refresh_from_db()
         self.assertEqual(
             self.dataset_view_1.product_sync_status,
-            DatasetView.SyncStatus.SYNCED
+            DatasetView.SyncStatus.OUT_OF_SYNC
         )
         self.assertEqual(
             self.dataset_view_1.vector_tile_sync_status,
-            DatasetView.SyncStatus.SYNCED
+            DatasetView.SyncStatus.OUT_OF_SYNC
         )
 
         # Other Dataset Views are affected.
@@ -218,6 +229,12 @@ class TestCheckAffectedViews(TestCase):
         )
         create_sql_view(static_view)
         init_view_privacy_level(static_view)
+        # init view entity count
+        calculate_entity_count_in_view(static_view)
+        static_view.product_sync_status = DatasetView.SyncStatus.SYNCED
+        static_view.vector_tile_sync_status = DatasetView.SyncStatus.SYNCED
+        static_view.save(update_fields=['product_sync_status',
+                                        'vector_tile_sync_status'])
 
         check_affected_dataset_views(
             dataset_id=self.dataset_1.id,


### PR DESCRIPTION
This is for:

- Fix failed test for sync status
- Fix status generate_view_resource_vector_tiles_task should be 'queued' instead of actively processing
- Change column to 'Data Products'
- Fix populate_tile_configs to set dataset status to be out of sync + all views without custom tiling config