### PR TITLE
Remove unused query entity list

### DIFF
--- a/django_project/georepo/api_views/entity.py
+++ b/django_project/georepo/api_views/entity.py
@@ -1129,7 +1129,7 @@ class EntityGeometryFuzzySearch(EntitySearchBase):
         description='Dataset UUID', type=openapi.TYPE_STRING
     )
     level_param = openapi.Parameter(
-        'level', openapi.IN_QUERY,
+        'admin_level', openapi.IN_QUERY,
         description='Admin level. Example: 0',
         type=openapi.TYPE_INTEGER,
         required=False
@@ -1283,7 +1283,7 @@ class EntityGeometryFuzzySearch(EntitySearchBase):
         dataset, max_privacy_level = self.get_dataset_obj(
             request, kwargs, self.search_source
         )
-        level = request.GET.get('level', None)
+        level = request.GET.get('admin_level', None)
         # json or geojson. Default to json
         format = self.request.GET.get('format', 'json')
         is_latest = request.GET.get('latest', None)

--- a/django_project/georepo/api_views/entity_view.py
+++ b/django_project/georepo/api_views/entity_view.py
@@ -141,7 +141,7 @@ class DatasetViewSearchBase(object):
         return super(DatasetViewSearchBase, self).get_response_data(
             request, *args, **kwargs
         )
-    
+
     def get_admin_level_param(self):
         admin_level = None
         kwargs_adm_level = self.kwargs.get('admin_level', None)

--- a/django_project/georepo/api_views/entity_view.py
+++ b/django_project/georepo/api_views/entity_view.py
@@ -1321,7 +1321,7 @@ class ViewFindEntityGeometryFuzzySearch(
             'uuid', openapi.IN_PATH,
             description='View UUID', type=openapi.TYPE_STRING
         ), openapi.Parameter(
-            'level', openapi.IN_QUERY,
+            'admin_level', openapi.IN_QUERY,
             description='Admin level. Example: 0',
             type=openapi.TYPE_INTEGER,
             required=False

--- a/django_project/georepo/api_views/entity_view.py
+++ b/django_project/georepo/api_views/entity_view.py
@@ -141,13 +141,28 @@ class DatasetViewSearchBase(object):
         return super(DatasetViewSearchBase, self).get_response_data(
             request, *args, **kwargs
         )
+    
+    def get_admin_level_param(self):
+        admin_level = None
+        kwargs_adm_level = self.kwargs.get('admin_level', None)
+        if kwargs_adm_level is not None:
+            admin_level = kwargs_adm_level
+        return admin_level
 
     def generate_response(self, entities, context=None):
         if entities is not None:
             # raw_sql to view to select id
+            admin_level_param = self.get_admin_level_param()
             raw_sql = (
                 'SELECT id from "{}"'
             ).format(str(self.kwargs.get('uuid')))
+            if admin_level_param is not None:
+                raw_sql = (
+                    'SELECT id from "{view}" where level={admin_level}'
+                ).format(
+                    view=str(self.kwargs.get('uuid')),
+                    admin_level=admin_level_param
+                )
             # Query existing entities with uuids found in views
             entities = entities.filter(
                 id__in=RawSQL(raw_sql, [])

--- a/django_project/georepo/tests/test_api_entity.py
+++ b/django_project/georepo/tests/test_api_entity.py
@@ -791,7 +791,7 @@ class TestApiEntity(EntityResponseChecker, TestCase):
         request = self.factory.post(
             reverse(
                 'v1:entity-fuzzy-search-by-geometry', kwargs=kwargs
-            ) + '?level=2',
+            ) + '?admin_level=2',
             data=data_1,
             format='json'
         )

--- a/django_project/georepo/tests/test_api_entity_view.py
+++ b/django_project/georepo/tests/test_api_entity_view.py
@@ -1305,7 +1305,7 @@ class EntityViewTestSuite(EntityResponseChecker):
         request = self.factory.post(
             reverse(
                 'v1:view-entity-fuzzy-search-by-geometry', kwargs=kwargs
-            ) + '?level=2',
+            ) + '?admin_level=2',
             data=data_1,
             format='json'
         )

--- a/django_project/georepo/utils/entity_query.py
+++ b/django_project/georepo/utils/entity_query.py
@@ -151,11 +151,11 @@ def do_generate_entity_query(entities, dataset_uuid, entity_type=None,
             values.append(f'{field_key}__label')
     # find max level to build query for the parent's code
     max_level = 0
-    max_level_entity = entities.order_by(
+    max_level_entity = entities.values('level').order_by(
         'level'
     ).last()
     if max_level_entity:
-        max_level = max_level_entity.level
+        max_level = max_level_entity['level']
     related = ''
     for i in range(max_level):
         related = related + (


### PR DESCRIPTION
This is for https://github.com/unicef-drp/GeoRepo/issues/1082

- Remove query whole Entity object to get the maximum level only
- Make it level field in API parameters consistent to be admin_level
- Add admin level to view query