### PR TITLE
add cache control to centroid file in azure blob

### DIFF
--- a/django_project/georepo/utils/azure_blob_storage.py
+++ b/django_project/georepo/utils/azure_blob_storage.py
@@ -40,7 +40,7 @@ class DirectoryClient:
         with open(source, 'rb') as data:
             self.client.upload_blob(name=dest, data=data)
 
-    def upload_gzip_file(self, source, dest):
+    def upload_gzip_file(self, source, dest, cache_control=None):
         """
         Upload a gzipped file
         """
@@ -48,7 +48,10 @@ class DirectoryClient:
             self.client.upload_blob(
                 name=dest,
                 data=data,
-                content_settings=ContentSettings(content_encoding='gzip')
+                content_settings=ContentSettings(
+                    content_encoding='gzip',
+                    cache_control=cache_control
+                )
             )
 
     def upload_dir(self, source, dest):

--- a/django_project/georepo/utils/centroid_exporter.py
+++ b/django_project/georepo/utils/centroid_exporter.py
@@ -271,7 +271,12 @@ class CentroidExporter(object):
             )
             client = DirectoryClient(settings.AZURE_STORAGE,
                                      settings.AZURE_STORAGE_CONTAINER)
-            client.upload_gzip_file(tmp_file_path, file_path)
+            max_age = settings.EXPORT_DATA_EXPIRY_IN_HOURS * 3600
+            client.upload_gzip_file(
+                tmp_file_path,
+                file_path,
+                cache_control=f'private, max-age={max_age}'
+            )
         else:
             dir_path = os.path.join(
                 settings.MEDIA_ROOT,


### PR DESCRIPTION
This is to add cache control to centroid cache file in the azure blob storage.
Previews:
![2024-02-19_14-01_1](https://github.com/unicef-drp/GeoRepo-OS/assets/5819076/5d7fc7d1-62d2-444d-8c90-4b498a69fbeb)

![2024-02-19_14-01](https://github.com/unicef-drp/GeoRepo-OS/assets/5819076/de3999bd-dbcd-4fb5-9ea0-ca84133bcec7)

![2024-02-19_14-00](https://github.com/unicef-drp/GeoRepo-OS/assets/5819076/34eca6d1-42db-4c6f-9505-55b05c366060)
