### PR TITLE
remove maxLength on name label

### DIFF
--- a/django_project/dashboard/src/components/Uploads/NameFieldFormControl.tsx
+++ b/django_project/dashboard/src/components/Uploads/NameFieldFormControl.tsx
@@ -50,9 +50,6 @@ interface NameFieldFormControlProps {
               onChange={val => props.handleNameLanguageChange(props.nameField.id, null, null, val.target.value, 'label')}
               disabled={props.isReadOnly}
               error={props.nameField.duplicateError}
-              inputProps={{
-                'maxLength': 10
-              }}
               style={{width: '100%'}}
             />
           </Grid>


### PR DESCRIPTION
Fix https://github.com/unicef-drp/GeoRepo/issues/1248

On exported shapefile, the long name is automatically truncated:

<img width="704" height="512" alt="image" src="https://github.com/user-attachments/assets/2d067bed-7cb3-4a57-875d-bb4d1c8f2e72" />
