### PR TITLE
Rename entities endpoint

### DIFF
--- a/django_project/core/api_orders.py
+++ b/django_project/core/api_orders.py
@@ -1,6 +1,10 @@
 
 # ordering API
 API_ORDERS = {
+    "00-search-entity": [
+        "search-entity-by-ucode",
+        "search-entity-by-concept-ucode"
+    ],
     "01-search-module": [],
     "02-search-dataset": [
         "search-dataset-list",
@@ -9,8 +13,6 @@ API_ORDERS = {
     "03-search-dataset-entity": [],
     "04-search-view": [],
     "05-search-view-entity": [
-        "search-entity-by-ucode",
-        "search-entity-by-concept-ucode",
         "search-view-entity-by-id",
         "search-view-entity-by-level",
         "search-view-entity-by-level-and-ucode",

--- a/django_project/georepo/api_views/api_collections.py
+++ b/django_project/georepo/api_views/api_collections.py
@@ -1,4 +1,5 @@
 # NOTE: change in tag, please also change API_ORDERS
+SEARCH_ENTITY_BASE_TAG = '00-search-entity'
 SEARCH_MODULE_TAG = '01-search-module'
 SEARCH_DATASET_TAG = '02-search-dataset'
 SEARCH_DATASET_ENTITY_TAG = '03-search-dataset-entity'

--- a/django_project/georepo/api_views/entity.py
+++ b/django_project/georepo/api_views/entity.py
@@ -1223,7 +1223,7 @@ class EntityFuzzySearch(EntitySearchBase):
 
 class EntityGeometryFuzzySearch(EntitySearchBase):
     """
-    Find closest geographical entity
+    Find closest geographical entities
 
     Search top 10 Geographical Entity that has closest match with \
         given geometry

--- a/django_project/georepo/api_views/entity_view.py
+++ b/django_project/georepo/api_views/entity_view.py
@@ -76,7 +76,8 @@ from georepo.utils.uuid_helper import get_uuid_value
 from georepo.utils.geojson import validate_geojson
 from georepo.api_views.api_collections import (
     SEARCH_VIEW_ENTITY_TAG,
-    OPERATION_VIEW_ENTITY_TAG
+    OPERATION_VIEW_ENTITY_TAG,
+    SEARCH_ENTITY_BASE_TAG
 )
 from georepo.utils.api_parameters import (
     common_api_params,
@@ -3240,7 +3241,7 @@ class FindEntityByUCode(APILoggingMixin, APIView):
 
     @swagger_auto_schema(
         operation_id='search-entity-by-ucode',
-        tags=[SEARCH_VIEW_ENTITY_TAG],
+        tags=[SEARCH_ENTITY_BASE_TAG],
         manual_parameters=[openapi.Parameter(
             'ucode', openapi.IN_PATH,
             description='Entity UCode',
@@ -3354,7 +3355,7 @@ class FindEntityByCUCode(FindEntityByUCode):
 
     @swagger_auto_schema(
         operation_id='search-entity-by-concept-ucode',
-        tags=[SEARCH_VIEW_ENTITY_TAG],
+        tags=[SEARCH_ENTITY_BASE_TAG],
         manual_parameters=[openapi.Parameter(
             'concept_ucode', openapi.IN_PATH,
             description='Entity Concept UCode',


### PR DESCRIPTION
For https://github.com/unicef-drp/GeoRepo/issues/1205#issuecomment-3696369708:

- for "/search/dataset/{uuid}/entity/geometry/" - change description from "Find closest geographical entity" to "Find closest geographical entities" (to align with View endpoint)

- move top 2 endpoints from Views section to a separate section, as they are not related to any view nor dataset:
