### PR TITLE
add health check endpoint

### DIFF
--- a/django_project/core/settings/project.py
+++ b/django_project/core/settings/project.py
@@ -51,6 +51,7 @@ LOCALE_PATHS = (absolute_path('locale'),)
 
 # Extra installed apps
 INSTALLED_APPS = INSTALLED_APPS + (
+    'health',
     'azure_auth',
     'core',
     'georepo',

--- a/django_project/core/urls.py
+++ b/django_project/core/urls.py
@@ -94,6 +94,7 @@ schema_view_v1 = get_schema_view(
 admin.autodiscover()
 
 urlpatterns = [
+    path('', include('health.urls')),
     re_path(r'^api/v1/docs/$', schema_view_v1.with_ui(
                 'swagger', cache_timeout=0),
             name='schema-swagger-ui'),

--- a/django_project/health/apps.py
+++ b/django_project/health/apps.py
@@ -5,5 +5,6 @@ from django.apps import AppConfig
 
 class HealthConfig(AppConfig):
     """Health check application configuration."""
+
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'health'

--- a/django_project/health/apps.py
+++ b/django_project/health/apps.py
@@ -1,0 +1,9 @@
+# coding=utf-8
+"""Application config for health check."""
+from django.apps import AppConfig
+
+
+class HealthConfig(AppConfig):
+    """Health check application configuration."""
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'health'

--- a/django_project/health/test_readiness.py
+++ b/django_project/health/test_readiness.py
@@ -52,7 +52,11 @@ class ReadinessProbeTest(TestCase):
 
     @patch('health.views.connection')
     def test_database_check_fails(self, mock_connection):
-        """Test readiness probe fails when database is down."""
+        """Test readiness probe fails when database is down.
+
+        :param mock_connection: Mocked database connection
+        :type mock_connection: MagicMock
+        """
         # Mock database connection failure
         mock_cursor = MagicMock()
         mock_cursor.execute.side_effect = Exception(
@@ -74,7 +78,11 @@ class ReadinessProbeTest(TestCase):
 
     @patch('health.views.cache')
     def test_redis_check_fails_on_set(self, mock_cache):
-        """Test readiness probe fails when Redis set operation fails."""
+        """Test readiness probe fails when Redis set operation fails.
+
+        :param mock_cache: Mocked cache object
+        :type mock_cache: MagicMock
+        """
         mock_cache.set.side_effect = Exception("Redis connection failed")
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 503)
@@ -83,7 +91,11 @@ class ReadinessProbeTest(TestCase):
 
     @patch('health.views.cache')
     def test_redis_check_fails_on_get(self, mock_cache):
-        """Test readiness probe fails when Redis get returns wrong value."""
+        """Test readiness probe fails when Redis get returns wrong value.
+
+        :param mock_cache: Mocked cache object
+        :type mock_cache: MagicMock
+        """
         mock_cache.set.return_value = None
         mock_cache.get.return_value = 'wrong_value'
         response = self.client.get(self.url)
@@ -107,7 +119,11 @@ class ReadinessProbeTest(TestCase):
     def test_storage_check_fails_when_usage_exceeds_threshold(
         self, mock_disk_usage
     ):
-        """Test storage check fails when disk usage exceeds 98%."""
+        """Test storage check fails when disk usage exceeds 98%.
+
+        :param mock_disk_usage: Mocked disk usage function
+        :type mock_disk_usage: MagicMock
+        """
         # Mock disk usage at 99% (exceeds 98% threshold)
         mock_disk_usage.return_value = MagicMock(
             total=10 * 1024**3,  # 10GB total
@@ -126,7 +142,11 @@ class ReadinessProbeTest(TestCase):
 
     @patch('health.views.shutil.disk_usage')
     def test_storage_check_passes_at_threshold_boundary(self, mock_disk_usage):
-        """Test storage check passes when exactly at 98% (not exceeding)."""
+        """Test storage check passes when exactly at 98% (not exceeding).
+
+        :param mock_disk_usage: Mocked disk usage function
+        :type mock_disk_usage: MagicMock
+        """
         # Mock disk usage at exactly 98%
         mock_disk_usage.return_value = MagicMock(
             total=10 * 1024**3,  # 10GB total
@@ -139,7 +159,11 @@ class ReadinessProbeTest(TestCase):
 
     @patch('health.views.shutil.disk_usage')
     def test_storage_check_with_custom_threshold(self, mock_disk_usage):
-        """Test storage check respects custom threshold setting."""
+        """Test storage check respects custom threshold setting.
+
+        :param mock_disk_usage: Mocked disk usage function
+        :type mock_disk_usage: MagicMock
+        """
         # Mock disk usage at 91%
         mock_disk_usage.return_value = MagicMock(
             total=10 * 1024**3,
@@ -159,7 +183,13 @@ class ReadinessProbeTest(TestCase):
     @patch('health.views.connection')
     @patch('health.views.cache')
     def test_multiple_checks_fail(self, mock_cache, mock_connection):
-        """Test readiness probe when multiple checks fail."""
+        """Test readiness probe when multiple checks fail.
+
+        :param mock_cache: Mocked cache object
+        :type mock_cache: MagicMock
+        :param mock_connection: Mocked database connection
+        :type mock_connection: MagicMock
+        """
         # Mock both database and Redis failures
         mock_cursor = MagicMock()
         mock_cursor.execute.side_effect = Exception("Database failed")

--- a/django_project/health/test_readiness.py
+++ b/django_project/health/test_readiness.py
@@ -1,0 +1,203 @@
+# coding=utf-8
+"""Health check API tests."""
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.core.cache import cache
+from unittest.mock import patch, MagicMock
+import tempfile
+
+
+@override_settings(
+    CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'unique-test-cache',
+        }
+    }
+)
+class ReadinessProbeTest(TestCase):
+    """Test suite for readiness probe endpoint."""
+
+    def setUp(self):
+        """Set up test environment."""
+        self.url = reverse('health-readiness')
+        # Clear cache before each test
+        cache.clear()
+
+    def tearDown(self):
+        """Clean up after tests."""
+        cache.clear()
+
+    def test_readiness_probe_all_healthy(self):
+        """Test readiness probe when all checks pass."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['status'], 'ready')
+        self.assertTrue(response.json()['checks']['database'])
+        self.assertTrue(response.json()['checks']['redis'])
+
+    def test_readiness_probe_returns_json(self):
+        """Test that readiness probe returns valid JSON."""
+        response = self.client.get(self.url)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        data = response.json()
+        self.assertIn('status', data)
+        self.assertIn('checks', data)
+
+    def test_database_check_passes(self):
+        """Test database connectivity check passes."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['checks']['database'])
+
+    @patch('health.views.connection')
+    def test_database_check_fails(self, mock_connection):
+        """Test readiness probe fails when database is down."""
+        # Mock database connection failure
+        mock_cursor = MagicMock()
+        mock_cursor.execute.side_effect = Exception(
+            "Database connection failed"
+        )
+        mock_connection.cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()['status'], 'not ready')
+        self.assertFalse(response.json()['checks']['database'])
+
+    def test_redis_check_passes(self):
+        """Test Redis connectivity check passes."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['checks']['redis'])
+
+    @patch('health.views.cache')
+    def test_redis_check_fails_on_set(self, mock_cache):
+        """Test readiness probe fails when Redis set operation fails."""
+        mock_cache.set.side_effect = Exception("Redis connection failed")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()['status'], 'not ready')
+        self.assertFalse(response.json()['checks']['redis'])
+
+    @patch('health.views.cache')
+    def test_redis_check_fails_on_get(self, mock_cache):
+        """Test readiness probe fails when Redis get returns wrong value."""
+        mock_cache.set.return_value = None
+        mock_cache.get.return_value = 'wrong_value'
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()['status'], 'not ready')
+        self.assertFalse(response.json()['checks']['redis'])
+
+    def test_storage_check_passes_with_low_usage(self):
+        """Test storage check passes when disk usage is below threshold."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with override_settings(
+                LOGS_DIRECTORY=temp_dir,
+                STORAGE_CRITICAL_THRESHOLD=98
+            ):
+                response = self.client.get(self.url)
+                self.assertEqual(response.status_code, 200)
+                self.assertTrue(response.json()['checks']['storage'])
+
+    @patch('health.views.shutil.disk_usage')
+    def test_storage_check_fails_when_usage_exceeds_threshold(
+        self, mock_disk_usage
+    ):
+        """Test storage check fails when disk usage exceeds 98%."""
+        # Mock disk usage at 99% (exceeds 98% threshold)
+        mock_disk_usage.return_value = MagicMock(
+            total=10 * 1024**3,  # 10GB total
+            used=9.9 * 1024**3,  # 9.9GB used (99%)
+            free=0.1 * 1024**3   # 0.1GB free
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with override_settings(
+                LOGS_DIRECTORY=temp_dir,
+                STORAGE_CRITICAL_THRESHOLD=98
+            ):
+                response = self.client.get(self.url)
+                self.assertEqual(response.status_code, 503)
+                self.assertEqual(response.json()['status'], 'not ready')
+                self.assertFalse(response.json()['checks']['storage'])
+
+    @patch('health.views.shutil.disk_usage')
+    def test_storage_check_passes_at_threshold_boundary(self, mock_disk_usage):
+        """Test storage check passes when exactly at 98% (not exceeding)."""
+        # Mock disk usage at exactly 98%
+        mock_disk_usage.return_value = MagicMock(
+            total=10 * 1024**3,  # 10GB total
+            used=9.8 * 1024**3,  # 9.8GB used (98%)
+            free=0.2 * 1024**3   # 0.2GB free
+        )
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['checks']['storage'])
+
+    @patch('health.views.shutil.disk_usage')
+    def test_storage_check_with_custom_threshold(self, mock_disk_usage):
+        """Test storage check respects custom threshold setting."""
+        # Mock disk usage at 91%
+        mock_disk_usage.return_value = MagicMock(
+            total=10 * 1024**3,
+            used=9.1 * 1024**3,
+            free=0.9 * 1024**3
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Test with 90% threshold - should fail
+            with override_settings(
+                LOGS_DIRECTORY=temp_dir,
+                STORAGE_CRITICAL_THRESHOLD=90
+            ):
+                response = self.client.get(self.url)
+                self.assertEqual(response.status_code, 503)
+                self.assertFalse(response.json()['checks']['storage'])
+
+    @patch('health.views.connection')
+    @patch('health.views.cache')
+    def test_multiple_checks_fail(self, mock_cache, mock_connection):
+        """Test readiness probe when multiple checks fail."""
+        # Mock both database and Redis failures
+        mock_cursor = MagicMock()
+        mock_cursor.execute.side_effect = Exception("Database failed")
+        mock_connection.cursor.return_value.__enter__.return_value = (
+            mock_cursor
+        )
+        mock_cache.set.side_effect = Exception("Redis failed")
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()['status'], 'not ready')
+        self.assertFalse(response.json()['checks']['database'])
+        self.assertFalse(response.json()['checks']['redis'])
+
+    def test_endpoint_allows_unauthenticated_access(self):
+        """Test that readiness endpoint doesn't require authentication."""
+        # Should work without any authentication
+        response = self.client.get(self.url)
+        # Should not return 401 or 403
+        self.assertNotEqual(response.status_code, 401)
+        self.assertNotEqual(response.status_code, 403)
+        # Should return either 200 or 503
+        self.assertIn(response.status_code, [200, 503])
+
+    def test_endpoint_only_accepts_get(self):
+        """Test that readiness endpoint only accepts GET requests."""
+        # GET should work
+        get_response = self.client.get(self.url)
+        self.assertIn(get_response.status_code, [200, 503])
+
+        # POST should not be allowed
+        post_response = self.client.post(self.url)
+        self.assertEqual(post_response.status_code, 405)
+
+        # PUT should not be allowed
+        put_response = self.client.put(self.url)
+        self.assertEqual(put_response.status_code, 405)
+
+        # DELETE should not be allowed
+        delete_response = self.client.delete(self.url)
+        self.assertEqual(delete_response.status_code, 405)

--- a/django_project/health/urls.py
+++ b/django_project/health/urls.py
@@ -1,0 +1,9 @@
+# coding=utf-8
+"""Health check API urls."""
+
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('ready/', views.readiness_probe, name='health-readiness'),
+]

--- a/django_project/health/views.py
+++ b/django_project/health/views.py
@@ -23,7 +23,13 @@ STORAGE_PATHS = {
 @api_view(['GET'])
 @permission_classes([AllowAny])
 def readiness_probe(request):
-    """Readiness probe - checks if the application is ready."""
+    """Readiness probe - checks if the application is ready.
+
+    :param request: HTTP request
+    :type request: Request
+    :return: HTTP response with readiness status
+    :rtype: Response
+    """
     checks = {
         "database": check_database(),
         "redis": check_redis(),
@@ -53,7 +59,11 @@ def readiness_probe(request):
 
 
 def check_database():
-    """Check database connectivity."""
+    """Check database connectivity.
+
+    :return: True if database is reachable, False otherwise
+    :rtype: bool
+    """
     try:
         with connection.cursor() as cursor:
             cursor.execute("SELECT 1")
@@ -64,7 +74,11 @@ def check_database():
 
 
 def check_redis():
-    """Check Redis connectivity."""
+    """Check Redis connectivity.
+
+    :return: True if Redis is reachable, False otherwise
+    :rtype: bool
+    """
     try:
         cache.set('health_check', 'ok', 10)
         result = cache.get('health_check')
@@ -83,7 +97,11 @@ def check_redis():
 
 
 def check_storage():
-    """Check storage disk space - fail if usage > 98%."""
+    """Check storage disk space - fail if usage > 98%.
+
+    :return: True if storage usage is below threshold, False otherwise
+    :rtype: bool
+    """
     try:
         critical_threshold = getattr(
             settings, 'STORAGE_CRITICAL_THRESHOLD', 98
@@ -115,7 +133,11 @@ def check_storage():
 
 
 def get_storage_info():
-    """Get detailed info for all storage locations."""
+    """Get detailed info for all storage locations.
+
+    :return: Dictionary with storage info or None if no paths available
+    :rtype: dict or None
+    """
     storage_info = {}
     for name, path in STORAGE_PATHS.items():
         if not path or not os.path.exists(path):

--- a/django_project/health/views.py
+++ b/django_project/health/views.py
@@ -1,0 +1,135 @@
+# coding=utf-8
+"""Health check API."""
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework import status
+from django.db import connection
+from django.core.cache import cache
+from django.conf import settings
+import logging
+import shutil
+import os
+
+logger = logging.getLogger(__name__)
+# Add more paths if necessary
+STORAGE_PATHS = {
+    'logs': getattr(settings, 'LOGS_DIRECTORY', None),
+    'media': getattr(settings, 'MEDIA_ROOT', None),
+    'static': getattr(settings, 'STATIC_ROOT', None),
+}
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def readiness_probe(request):
+    """Readiness probe - checks if the application is ready."""
+    checks = {
+        "database": check_database(),
+        "redis": check_redis(),
+        "storage": check_storage(),
+    }
+
+    storage_info = get_storage_info()
+
+    # Filter out None values (optional checks)
+    checks = {k: v for k, v in checks.items() if v is not None}
+    all_healthy = all(checks.values())
+
+    response_data = {
+        "status": "ready" if all_healthy else "not ready",
+        "checks": checks,
+    }
+    if storage_info:
+        response_data["storage_info"] = storage_info
+
+    return Response(
+        response_data,
+        status=(
+            status.HTTP_200_OK if all_healthy else
+            status.HTTP_503_SERVICE_UNAVAILABLE
+        )
+    )
+
+
+def check_database():
+    """Check database connectivity."""
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+        return True
+    except Exception as e:
+        logger.error(f"Database health check failed: {str(e)}")
+        return False
+
+
+def check_redis():
+    """Check Redis connectivity."""
+    try:
+        cache.set('health_check', 'ok', 10)
+        result = cache.get('health_check')
+
+        if result != 'ok':
+            logger.error(
+                "Redis health check failed: could not retrieve test value"
+            )
+            return False
+
+        cache.delete('health_check')
+        return True
+    except Exception as e:
+        logger.error(f"Redis health check failed: {str(e)}")
+        return False
+
+
+def check_storage():
+    """Check storage disk space - fail if usage > 98%."""
+    try:
+        critical_threshold = getattr(
+            settings, 'STORAGE_CRITICAL_THRESHOLD', 98
+        )
+        all_healthy = True
+
+        for name, path in STORAGE_PATHS.items():
+            if not path or not os.path.exists(path):
+                continue
+
+            disk_usage = shutil.disk_usage(path)
+            usage_percent = round(
+                (disk_usage.used / disk_usage.total) * 100, 2
+            )
+
+            if usage_percent > critical_threshold:
+                logger.error(
+                    f"Storage '{name}' CRITICAL: {usage_percent:.2f}% "
+                    f"used at {path}"
+                )
+                all_healthy = False
+            else:
+                logger.debug(f"Storage '{name}' OK: {usage_percent:.2f}% used")
+
+        return all_healthy
+    except Exception as e:
+        logger.error(f"Storage health check failed: {str(e)}")
+        return False
+
+
+def get_storage_info():
+    """Get detailed info for all storage locations."""
+    storage_info = {}
+    for name, path in STORAGE_PATHS.items():
+        if not path or not os.path.exists(path):
+            continue
+        try:
+            disk_usage = shutil.disk_usage(path)
+            usage_percent = (disk_usage.used / disk_usage.total) * 100
+            storage_info[name] = {
+                "path": path,
+                "total_gb": round(disk_usage.total / (1024**3), 2),
+                "used_gb": round(disk_usage.used / (1024**3), 2),
+                "free_gb": round(disk_usage.free / (1024**3), 2),
+                "usage_percent": round(usage_percent, 2),
+            }
+        except Exception as e:
+            logger.warning(f"Could not get storage info for {name}: {e}")
+    return storage_info if storage_info else None


### PR DESCRIPTION
Fix https://github.com/unicef-drp/GeoRepo/issues/1264


Endpoint: GET /ready/

Response:
```
HTTP 200 OK
Allow: GET, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "status": "ready",
    "checks": {
        "database": true,
        "redis": true,
        "storage": true
    },
    "storage_info": {
        "logs": {
            "path": "/home/web/logs",
            "total_gb": 434.36,
            "used_gb": 344.81,
            "free_gb": 67.42,
            "usage_percent": 79.38
        },
        "media": {
            "path": "/home/web/media",
            "total_gb": 434.36,
            "used_gb": 344.81,
            "free_gb": 67.42,
            "usage_percent": 79.38
        },
        "static": {
            "path": "/home/web/static",
            "total_gb": 434.36,
            "used_gb": 344.81,
            "free_gb": 67.42,
            "usage_percent": 79.38
        }
    }
}
```